### PR TITLE
add prefix to html class to prevent conflict with other plugins

### DIFF
--- a/acf-link_picker-v4.php
+++ b/acf-link_picker-v4.php
@@ -146,8 +146,8 @@ class acf_field_link_picker extends acf_field {
                 </div>
             </p>
             <p>
-                <a href="" class="link-btn acf-button grey" id="link-picker-<?php echo $field['key']; ?>"><?php if (!$exists) { _e('Insert Link', 'acf-link_picker'); }else{ _e('Edit Link', 'acf-link_picker'); } ?></a>
-                <a href="" class="link-remove-btn acf-button grey" id="link-picker-<?php echo $field['key']; ?>-remove"<?php if (!$exists) { echo ' style="display:none;"'; } ?>><?php _e('Remove Link', 'acf-link_picker'); ?></a>
+                <a href="" class="acf-lp-link-btn acf-button grey" id="link-picker-<?php echo $field['key']; ?>"><?php if (!$exists) { _e('Insert Link', 'acf-link_picker'); }else{ _e('Edit Link', 'acf-link_picker'); } ?></a>
+                <a href="" class="acf-lp-link-remove-btn acf-button grey" id="link-picker-<?php echo $field['key']; ?>-remove"<?php if (!$exists) { echo ' style="display:none;"'; } ?>><?php _e('Remove Link', 'acf-link_picker'); ?></a>
             </p>
 		</div>
 		<?php

--- a/acf-link_picker-v5.php
+++ b/acf-link_picker-v5.php
@@ -182,10 +182,10 @@ class acf_field_link_picker extends acf_field {
                 </div>
             </div>
             <p>
-                <a href="" class="link-btn acf-button grey" id="link-picker-<?php echo $field['id']; ?>">
+                <a href="" class="acf-lp-link-btn acf-button grey" id="link-picker-<?php echo $field['id']; ?>">
                 	<?php if (!$exists) { _e('Insert Link', 'acf-link_picker'); }else{ _e('Edit Link', 'acf-link_picker'); } ?>
                 </a>
-                <a href="" class="link-remove-btn acf-button grey" id="link-picker-<?php echo $field['id']; ?>-remove"<?php if (!$exists) { echo ' style="display:none;"'; } ?>>
+                <a href="" class="acf-lp-link-remove-btn acf-button grey" id="link-picker-<?php echo $field['id']; ?>-remove"<?php if (!$exists) { echo ' style="display:none;"'; } ?>>
                 	<?php _e('Remove Link', 'acf-link_picker'); ?>
                 </a>
             </p>

--- a/js/input.js
+++ b/js/input.js
@@ -47,7 +47,7 @@
   
     function initialize_field( $el ) {
 
-        $el.on('click', '.link-btn', function(event) 
+        $el.on('click', '.acf-lp-link-btn', function(event)
         {
             trap_events(event);
 
@@ -80,7 +80,7 @@
             return false;
         });
 
-        $el.on('click', '.link-remove-btn', function(event) 
+        $el.on('click', '.acf-lp-link-remove-btn', function(event)
         {
             var thisID = $(this).attr("id").replace("-remove", "");
             doingLink = thisID;


### PR DESCRIPTION
`.link-btn` class looks very common and may conflict with other plugins. In my case it conflicts with `.link-btn` from WP Media Folder plugin (https://www.joomunited.com/wordpress-products/wp-media-folder)
