### PR TITLE
Fix for issues caused by postid_lookup finishing after the link selector has been closed

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -40,8 +40,19 @@
             'action': 'link_picker_postid_lookup',
             'url': url
         };
+
+        var didLink = doingLink;
         $.post(ajaxurl, ajax_data, function(response) {
-            $hidden_postid.val(response);
+            // we are still doing the same link
+            if(didLink == doingLink){
+                $hidden_postid.val(response);
+            }
+
+            // the link was selected before the ajax call finished
+            if($('#' + didLink + '-url').val() == url){
+                $('#' + didLink + '-postid').val(response);
+                $('#' + didLink + '-postid-label').html(response);
+            }
         });
     }
   


### PR DESCRIPTION
If the user quickly selected a link from the page selector, the postid_lookup would finish too late causing the postid to not get correctly updated. It's also possible the wrong hidden postid may have been update if the user were to quickly open a different link selector.
