### PR TITLE
Fix initialization when link field is the only wysiwyg field

### DIFF
--- a/acf-link_picker-v5.php
+++ b/acf-link_picker-v5.php
@@ -125,8 +125,9 @@ class acf_field_link_picker extends acf_field {
 	*/
 	
 	function render_field( $field ) {
-		
-		
+
+		acf_enqueue_uploader();
+
 		/*
 		*  Review the data of $field.
 		*  This will show what data is available


### PR DESCRIPTION
It resolves #16. `acf_enqueue_uploader` is used by all wysiwyg acf pro fields to enqueue all necessary WP media scripts and assets.
